### PR TITLE
Deleted fixed font size

### DIFF
--- a/com.github.eclipsecolortheme.themes/src/main/resources/themes/css/juno.css
+++ b/com.github.eclipsecolortheme.themes/src/main/resources/themes/css/juno.css
@@ -5,7 +5,6 @@
 }
 
 .MPartStack {
-	font-size: 12;
 	swt-simple: false;
 	swt-mru-visible: false;
 	swt-unselected-tabs-color: #333333 #333333 #333333 100% 100%;


### PR DESCRIPTION
Deleted fixed font size so it can be changed through "Preferences" menu. It is not that difficult to change it manually by editing the .css file, but it can save a lot of time to some folks (I spend like an hour trying to change font size via Eclipse's Preference menu)
